### PR TITLE
adding team page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 docs/_build
+*.ipynb_checkpoints

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -51,3 +51,11 @@ html_logo = "_static/logo.png"
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ["_static"]
+
+
+# -- Custom scripts ----------------------------------------------------------
+
+from subprocess import run
+from pathlib import Path
+
+run(f"python {Path(__file__).parent.joinpath('update_team.py')}".split())

--- a/docs/index.md
+++ b/docs/index.md
@@ -68,6 +68,7 @@ on and our plans for what's coming next.
 ```{toctree}
 about.md
 tools.md
+team.md
 updates/index.md
 examples.md
 ```

--- a/docs/team.md
+++ b/docs/team.md
@@ -1,0 +1,12 @@
+# Team members
+
+The Executable Books team is a collection of scientists, scholars, and technologists
+around the world. We welcome participation and contribution from the community.
+If you'd like to join the team, please get in touch!
+
+Below are the core `executablebooks` team members. 
+
+## Team
+
+```{include} team_panels_code.txt
+```

--- a/docs/team_panels_code.txt
+++ b/docs/team_panels_code.txt
@@ -1,0 +1,33 @@
+
+````{panels}
+---
+column: col-lg-4 col-md-4 col-sm-6 col-xs-12 p-2
+card: text-center
+---
+
+
+![avatar](https://avatars1.githubusercontent.com/u/1839645?v=4)
+++++++++++++++
+[@choldgraf](https://github.com/choldgraf)
+---
+
+![avatar](https://avatars1.githubusercontent.com/u/2997570?v=4)
+++++++++++++++
+[@chrisjsewell](https://github.com/chrisjsewell)
+---
+
+![avatar](https://avatars0.githubusercontent.com/u/3887684?v=4)
+++++++++++++++
+[@jstac](https://github.com/jstac)
+---
+
+![avatar](https://avatars3.githubusercontent.com/u/8263752?v=4)
+++++++++++++++
+[@mmcky](https://github.com/mmcky)
+---
+
+![avatar](https://avatars2.githubusercontent.com/u/33075058?v=4)
+++++++++++++++
+[@najuzilu](https://github.com/najuzilu)
+
+````

--- a/docs/update_team.py
+++ b/docs/update_team.py
@@ -1,0 +1,36 @@
+"""Update the directive we use to build the team page with latest results."""
+from requests import get
+from IPython.display import Markdown
+from pathlib import Path
+from textwrap import dedent
+
+# Pull latest team from github
+print("Updating team page...")
+team_url = "https://api.github.com/orgs/executablebooks/members"
+team = get(team_url).json()
+
+# Generate the markdown for each member
+people = []
+for person in team:
+    this_person = f"""
+    ![avatar]({person['avatar_url']})
+    ++++++++++++++
+    [@{person['login']}]({person['html_url']})
+    """
+    people.append(this_person)
+people_md = dedent("---\n".join(people))
+
+# Use the panels directive to build our team and write to txt
+md = f"""
+````{{panels}}
+---
+column: col-lg-4 col-md-4 col-sm-6 col-xs-12 p-2
+card: text-center
+---
+
+{people_md}
+````
+"""
+Path("team_panels_code.txt").write_text(md)
+
+


### PR DESCRIPTION
This adds a team page to our documentation by pulling the latest information from https://github.com/orgs/executablebooks/people . It uses @chrisjsewell 's sphinx-panels to do the rendering, which is awesomely easy