### PR TITLE
Corrected link syntax in Tools > MyST section.

### DIFF
--- a/docs/tools.md
+++ b/docs/tools.md
@@ -56,7 +56,7 @@ MyST has the following main features:
   as line commenting and footnotes.
 * **[A Sphinx-independent parser of MyST markdown](https://myst-parser.readthedocs.io/en/latest/using/use_api.html)** that can be extended
   to add new functionality and outputs for MyST.
-* **[A superset of CommonMark markdown][https://commonmark.org/]**. Any CommonMark markdown
+* **[A superset of CommonMark markdown](https://commonmark.org/)**. Any CommonMark markdown
   (such as Jupyter Notebook markdown) is natively supported by the MyST parser.
 
 ## MyST-NB


### PR DESCRIPTION
The square bracket meant the link wasn´t rendered correctly in the final page: 

![Screenshot_2020-06-17 Tools — Executable Book Project documentation](https://user-images.githubusercontent.com/64686/84938075-fcdf2e80-b0dc-11ea-8ab0-1b0b8f9fe7fa.png)
