### PR TITLE
📚 DOCS: adding contributing guidelines from source

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 docs/_build
 *.ipynb_checkpoints
+docs/contributing.md

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -57,5 +57,11 @@ html_static_path = ["_static"]
 
 from subprocess import run
 from pathlib import Path
+import requests
 
+# Update the team page from github membership
 run(f"python {Path(__file__).parent.joinpath('update_team.py')}".split())
+# Grab the latest contributing docs
+url_contributing = "https://raw.githubusercontent.com/executablebooks/.github/master/CONTRIBUTING.md"
+resp = requests.get(url_contributing, allow_redirects=True)
+Path('contributing.md').write_bytes(resp.content)

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -10,7 +10,7 @@ Below are examples of books that have been generated with the EBP toolchain.
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 ![](https://jupyterbook.org/_static/logo.png)
 
-...
+---
 [QuantEcon](https://executablebooks.github.io/quantecon-example/docs/index.html)
 ^^^^^^^^^
 ![](https://executablebooks.github.io/quantecon-example/_static/qe-logo-large.png)

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,7 +8,7 @@ computational narratives using the Jupyter ecosystem.
 ## The EBP's technical goals
 
 The goal of the EBP is to build tools that facilitate creating
-professional computational narratives (books, lecture series, articles, etc.) 
+professional computational narratives (books, lecture series, articles, etc.)
 using open source tools. We want users in the scientific, academic,
 and data science communities to be able to do the following:
 
@@ -16,7 +16,7 @@ and data science communities to be able to do the following:
   These files include rich content - outputs from running code, references
   and cross-references, equations, etc.
 * **Execute content and cache the results**. Intelligent caching means
-  that only modified code cells are re-run. 
+  that only modified code cells are re-run.
 * **Combine cached outputs with content files with a document model**. Using
   the excellent [Sphinx](https://www.sphinx-doc.org/en/master/) documentation
   stack, documents can include many features for publishing, such as
@@ -68,6 +68,7 @@ on and our plans for what's coming next.
 ```{toctree}
 about.md
 tools.md
+contributing.md
 team.md
 updates/index.md
 examples.md


### PR DESCRIPTION
This adds a little `requests` grab so we can use the latest `contributing.md` in our Sphinx documentation in meta. Also fixes a syntax bug in our examples page.