### PR TITLE
📚 DOCS: Add calendar

### DIFF
--- a/.github/ISSUE_TEMPLATES/team-meeting.md
+++ b/.github/ISSUE_TEMPLATES/team-meeting.md
@@ -1,0 +1,24 @@
+---
+name: Team Meeting 📅
+about: A team meeting
+title: 'Team Meeting - <MONTH>'
+labels: meeting
+assignees: ''
+---
+
+Hello @executablebooks/ebpteam! This is an issue to track the next Executable Books team meeting! Here's some relevant information:
+
+- **Date**: <YYYY-MM-DD at HH Sydney Time> (or [your timezone](https://arewemeetingyet.com/Sydney/YYYY-MM-DD/HH:MM/EBP-Team-Meeting)).
+- **Agenda+Video links**: [HackMD](https://hackmd.io/THymMOAmSICp8rJdB6_Z1w?edit)
+
+If you'd like to discuss something at the meeting, please add an item to the agenda!
+
+# Tasks
+
+- [ ] Update dates and make sure HackMD information is correct
+- [ ] Add discussion items
+- [ ] Have the meeting
+- [ ] Turn any follow-ups into issues/comments/etc
+- [ ] Copy the meeting notes to the docs
+- [ ] Remove notes from HackMD to prep for next meeting
+- [ ] Done 🎉

--- a/docs/index.md
+++ b/docs/index.md
@@ -73,6 +73,7 @@ on and our plans for what's coming next.
 contributing.md
 developer.md
 team.md
+meetings.md
 feature-vote.md
 gallery.md
 ```

--- a/docs/meetings.md
+++ b/docs/meetings.md
@@ -1,0 +1,12 @@
+# Team Meetings
+
+The Executable Books team has meetings on the **first Thursday of each month** for one hour.
+We use [this HackMD for an agenda](https://hackmd.io/THymMOAmSICp8rJdB6_Z1w?edit).
+If you'd like to discuss something at a meeting, add an entry in the HackMD before the meeting.
+
+## Team Calendar
+
+This calendar has dates for upcoming events in the Executable Books community.
+You can [find the calendar URL here](https://calendar.google.com/calendar/u/0/embedhelper?src=s425j1984fmcs7u4cdmdmpau9o%40group.calendar.google.com&ctz=America%2FLos_Angeles).
+
+<iframe src="https://calendar.google.com/calendar/embed?height=600&amp;wkst=1&amp;bgcolor=%23ffffff&amp;ctz=America%2FLos_Angeles&amp;src=czQyNWoxOTg0Zm1jczd1NGNkbWRtcGF1OW9AZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ&amp;color=%237986CB" style="border:solid 1px #777" width="800" height="600" frameborder="0" scrolling="no"></iframe>

--- a/docs/meetings.md
+++ b/docs/meetings.md
@@ -1,12 +1,12 @@
 # Team Meetings
 
 The Executable Books team has meetings on the **first Thursday of each month** for one hour.
-We use [this HackMD for an agenda](https://hackmd.io/THymMOAmSICp8rJdB6_Z1w?edit).
+We use [this HackMD for an agenda](https://hackmd.io/THymMOAmSICp8rJdB6_Z1w?edit) and relevant meeting information.
 If you'd like to discuss something at a meeting, add an entry in the HackMD before the meeting.
 
 ## Team Calendar
 
 This calendar has dates for upcoming events in the Executable Books community.
-You can [find the calendar URL here](https://calendar.google.com/calendar/u/0/embedhelper?src=s425j1984fmcs7u4cdmdmpau9o%40group.calendar.google.com&ctz=America%2FLos_Angeles).
+You can [find the calendar URL here](https://calendar.google.com/calendar/embed?src=s425j1984fmcs7u4cdmdmpau9o%40group.calendar.google.com&ctz=America%2FLos_Angeles).
 
 <iframe src="https://calendar.google.com/calendar/embed?height=600&amp;wkst=1&amp;bgcolor=%23ffffff&amp;ctz=America%2FLos_Angeles&amp;src=czQyNWoxOTg0Zm1jczd1NGNkbWRtcGF1OW9AZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ&amp;color=%237986CB" style="border:solid 1px #777" width="800" height="600" frameborder="0" scrolling="no"></iframe>

--- a/docs/updates/2021-06-18-update-toc.md
+++ b/docs/updates/2021-06-18-update-toc.md
@@ -155,4 +155,4 @@ parts:
 ## Step 5: We're done!
 
 This TOC structure is now compatible with the new Jupyter Book TOC style.
-We have taken a minimal set of steps here to convert over the old TOC structure, but if you'd like to learn more about the Table of Contents, check out {ref}`jb:toc/configuration-structure`.
+We have taken a minimal set of steps here to convert over the old TOC structure, but if you'd like to learn more about the Table of Contents, check out {ref}`jb:toc/structure`.


### PR DESCRIPTION
This adds some information about EBP team meetings, and adds links to a calendar with team meeting dates, as well as a HackMD with an agenda template.

It also proposes that we have **our first team meeting on Thursday, July 1st at 7am Sydney time**.

cc @executablebooks/ebpteam to see if this works for folks!

related to https://github.com/executablebooks/meta/issues/379