### PR TITLE
[GALLERY] add quantecon projects that have been migrated to jupyter-book

### DIFF
--- a/docs/gallery.yml
+++ b/docs/gallery.yml
@@ -1,3 +1,19 @@
+- name: Python Programming for Economics and Finance
+  website: https://python-programming.quantecon.org/intro.html
+  repository: https://github.com/QuantEcon/lecture-python-programming.myst
+  image: https://python-programming.quantecon.org/_static/qe-logo.png
+- name: Quantitative Economics with Python
+  website: https://python.quantecon.org/intro.html
+  repository: https://github.com/QuantEcon/lecture-python.myst
+  image: https://python.quantecon.org/_static/qe-logo.png
+- name: Advanced Quantitative Economics with Python
+  website: https://python-advanced.quantecon.org/intro.html
+  repository: https://github.com/QuantEcon/lecture-python-advanced.myst
+  image: https://python-advanced.quantecon.org/_static/qe-logo.png
+- name: Introduction to Economic Modeling and Data Science
+  website: https://datascience.quantecon.org/intro.html
+  repository: https://github.com/QuantEcon/lecture-datascience.myst
+  image: https://datascience.quantecon.org/_static/datascience-logo.png
 - name: Explaining neural networks in raw Python
   website: https://bronwojtek.github.io/neuralnets-in-raw-python/docs/index.html
   repository: https://github.com/bronwojtek/neuralnets-in-raw-python

--- a/docs/gallery.yml
+++ b/docs/gallery.yml
@@ -38,10 +38,6 @@
   image: https://aquaulb.github.io/book_solving_pde_mooc/_static/logo.png
   website: https://aquaulb.github.io/book_solving_pde_mooc/solving_pde_mooc/notebooks/01_Introduction/01_00_Preface.html
   repository: https://github.com/aquaULB/solving_pde_mooc
-- name: Quantitative Economics with Python
-  website: https://executablebooks.github.io/quantecon-example/docs/index.html
-  repository: https://github.com/executablebooks/quantecon-example
-  image: https://executablebooks.github.io/quantecon-example/_static/qe-logo-large.png
 - name: Intro to Cultural Analytics
   website: https://melaniewalsh.github.io/Intro-Cultural-Analytics/welcome.html
   repository: https://github.com/melaniewalsh/Intro-Cultural-Analytics

--- a/docs/gallery.yml
+++ b/docs/gallery.yml
@@ -65,6 +65,7 @@
 - name: Continuous Time Markov Chains
   website: https://jstac.github.io/continuous_time_mcs/intro.html
   repository: http://github.com/jstac/continuous_time_mcs
+  image: https://python-programming.quantecon.org/_static/qe-logo.png
 - name: Statistics and Data Science
   website: https://cranmer.github.io/stats-ds-book/intro.html
   repository: https://github.com/cranmer/stats-ds-book

--- a/docs/gallery.yml
+++ b/docs/gallery.yml
@@ -5,11 +5,11 @@
 - name: Quantitative Economics with Python
   website: https://python.quantecon.org/intro.html
   repository: https://github.com/QuantEcon/lecture-python.myst
-  image: https://python.quantecon.org/_static/qe-logo-large.png
+  image: https://python-programming.quantecon.org/_static/qe-logo.png
 - name: Advanced Quantitative Economics with Python
   website: https://python-advanced.quantecon.org/intro.html
   repository: https://github.com/QuantEcon/lecture-python-advanced.myst
-  image: https://python-advanced.quantecon.org/_static/qe-logo-large.png
+  image: https://python-programming.quantecon.org/_static/qe-logo.png
 - name: Introduction to Economic Modeling and Data Science
   website: https://datascience.quantecon.org/intro.html
   repository: https://github.com/QuantEcon/lecture-datascience.myst

--- a/docs/gallery.yml
+++ b/docs/gallery.yml
@@ -5,11 +5,11 @@
 - name: Quantitative Economics with Python
   website: https://python.quantecon.org/intro.html
   repository: https://github.com/QuantEcon/lecture-python.myst
-  image: https://python.quantecon.org/_static/qe-logo.png
+  image: https://python.quantecon.org/_static/qe-logo-large.png
 - name: Advanced Quantitative Economics with Python
   website: https://python-advanced.quantecon.org/intro.html
   repository: https://github.com/QuantEcon/lecture-python-advanced.myst
-  image: https://python-advanced.quantecon.org/_static/qe-logo.png
+  image: https://python-advanced.quantecon.org/_static/qe-logo-large.png
 - name: Introduction to Economic Modeling and Data Science
   website: https://datascience.quantecon.org/intro.html
   repository: https://github.com/QuantEcon/lecture-datascience.myst


### PR DESCRIPTION
This adds the `jupyter-book` projects from `quantecon`