### PR TITLE
🔧 MAINTAIN: Pin sphinx requirement to v3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+sphinx~=3.5
 myst-parser[linkify]
 myst-nb
 sphinx-book-theme


### PR DESCRIPTION
Without this, sphinx v2 was being installed