### PR TITLE
Automate team meeting issue update

### DIFF
--- a/.github/ISSUE_TEMPLATE/team-meeting.md
+++ b/.github/ISSUE_TEMPLATE/team-meeting.md
@@ -1,29 +1,27 @@
 ---
 name: Team Meeting 📅
 about: A team meeting
-title: 'Team Meeting - <MONTH> <DD>'
+title: 'Team Meeting - {{ MONTH, DAY }}
 labels: meeting
 assignees: ''
 ---
 
 Hello @executablebooks/ebpteam! This is an issue to track the next Executable Books team meeting! Here's some relevant information:
 
-- **Date**: <YYYY-MM-DD> at 7AM Sydney Time (or [your timezone](https://arewemeetingyet.com/Sydney/YYYY-MM-DD/07:00/EBP-Team-Meeting)).
+- **Date**: {{ YYYY-MM-DD }} at 7AM Sydney Time (or [your timezone](https://arewemeetingyet.com/Sydney/{{ YYYY-MM-DD }}/07:00/EBP-Team-Meeting)).
 - **Agenda+Video links**: [HackMD](https://hackmd.io/THymMOAmSICp8rJdB6_Z1w?edit)
-- **Google Calendar link**: {{ insert link here }}
+- **Google Calendar link**: {{ PUBLISH CALENDAR EVENT AND PASTE LINK HERE }}
 
 If you'd like to discuss something at the meeting, please add an item to the agenda!
 
-# Before the meeting
+### Before the meeting
 
 - [ ] Update dates and make sure HackMD information is correct
 - [ ] Create an event link from Google Calendar and paste above.
 - [ ] Add discussion items
   
- # After the meeting
+### After the meeting
 
 - [ ] Turn any follow-ups into issues/comments/etc
 - [ ] Copy the meeting notes to the docs
-- [ ] Remove notes from HackMD to prep for next meeting
-- [ ] Create issue for the next team meeting and pin it
-- [ ] Done 🎉
+- [ ] Remove notes and clean up HackMD

--- a/.github/workflows/create-meeting-issue.yml
+++ b/.github/workflows/create-meeting-issue.yml
@@ -1,0 +1,18 @@
+# Open up a Team Meeting issue to prep for the meeting
+name: Create an issue on push
+on:
+  schedule:
+    # 25th day of the month, so we have a bit of lead time before the next meeting
+    - cron: '0 0 25 * *'
+  workflow_dispatch:
+    
+jobs:
+  create-team-issue:
+    runs-on: ubuntu-latest
+    with:
+      filename: .github/ISSUE_TEMPLATE/team-meeting.md
+    steps:
+      - uses: actions/checkout@v2
+      - uses: JasonEtco/create-an-issue@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This adds an action that will update a team meeting issue, so that we don't have to do it manually.

Since this is a minor change I'll plan to merge in a few days unless there are objections.