### PR TITLE
MAINT: Add a linkcheck action

### DIFF
--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -23,4 +23,9 @@ jobs:
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
         with:
-          args: docs/_build/**/*.html
+          fail: true
+          args: |
+            docs/_build/**/*.html \
+            --exclude-link-local \
+            --exclude mailto \
+            --exclude discuss.executablebooks.org

--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -16,11 +16,11 @@ jobs:
       - name: Build the documentation
         run: |
           pip install -r requirements.txt
-          sphinx-build . _build/html
+          sphinx-build docs docs/_build/html
 
       - name: Link Checker
         uses: lycheeverse/lychee-action@v1.2.0
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
         with:
-          args: _build/**/*.html
+          args: docs/_build/**/*.html

--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -1,18 +1,21 @@
-name: Check links
+name: Build documentation
 
 on:
-  push:
   pull_request:
 
 jobs:
-  linkChecker:
+  check-links:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '3.9'
+          cache: 'pip'
 
       - name: Build the documentation
         run: |
-          pip install requirements.txt
+          pip install -r requirements.txt
           sphinx-build . _build/html
 
       - name: Link Checker

--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -1,0 +1,23 @@
+name: Check links
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  linkChecker:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Build the documentation
+        run: |
+          pip install requirements.txt
+          sphinx-build . _build/html
+
+      - name: Link Checker
+        uses: lycheeverse/lychee-action@v1.2.0
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+        with:
+          args: _build/**/*.html

--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -24,8 +24,4 @@ jobs:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
         with:
           fail: true
-          args: |
-            docs/_build/**/*.html \
-            --exclude-link-local \
-            --exclude mailto \
-            --exclude discuss.executablebooks.org
+          args: docs/_build/**/*.html --exclude-link-local --exclude mailto --exclude discuss.executablebooks.org

--- a/docs/gallery.yml
+++ b/docs/gallery.yml
@@ -1,7 +1,7 @@
 - name: Graph Pandas
   website: https://pandas.liuzaoqi.com/
   repository: https://github.com/liuhuanshuo/zaoqi-book
-  image: https://pic.liuzaoqi.com/picgo/202201071423076.png
+  image: https://pandas.liuzaoqi.com/_static/mylogo.png
 - name: The Data Science Interview Book
   website: https://dipranjan.github.io/dsinterviewqns/intro.html
   repository: https://github.com/dipranjan/dsinterviewqns

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -22,7 +22,7 @@ Jupyter Book has the following main features:
 * **[Execute and cache your book's content](https://jupyterbook.org/content/execute.html)**. For `.ipynb` and
   markdown notebooks, execute code and insert the latest outputs into your book.
   In addition, cache and re-use outputs to be used later.
-* **[Insert notebook outputs into your content](https://jupyterbook.org/content/glue.html)**. Generate outputs
+* **[Insert notebook outputs into your content](https://jupyterbook.org/content/executable/output-insert.html)**. Generate outputs
   as you build your documentation, and insert them in-line with your content across pages.
 * **[Add interactivity to your book](https://jupyterbook.org/interactive/launchbuttons.html)**. You can
   toggle visibility of cells, connect with an online service like Binder,

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -90,7 +90,7 @@ interactive book. It has the following primary features:
 
 * **[Bootstrap 4](https://getbootstrap.com/docs/4.0/getting-started/introduction/)**
   for visual elements and functionality.
-* **[Flexible content layout](https://sphinx-book-theme.readthedocs.io/en/latest/layout.html)** that is inspired by beautiful online books,
+* **[Flexible content layout](https://sphinx-book-theme.readthedocs.io/en/latest/content-blocks.html)** that is inspired by beautiful online books,
   such as [the Edward Tufte CSS guide](https://edwardtufte.github.io/tufte-css/)
 * **[Visual classes designed for Jupyter Notebooks](https://sphinx-book-theme.readthedocs.io/en/latest/notebooks.html)**. Cell inputs, outputs,
   and interactive functionality are all supported.
@@ -126,8 +126,8 @@ Here are its main features:
 - Follows the __[CommonMark spec](http://spec.commonmark.org/)__ for baseline parsing
 - Configurable syntax: You can add new rules and even replace existing ones
 - Pluggable: Adds syntax extensions to extend the parser (see the [plugin list](https://markdown-it-py.readthedocs.io/en/latest/plugins.html#md-plugins))
-- High speed (see our [benchmarking tests](https://markdown-it-py.readthedocs.io/en/latest/security.html#md-performance))
-- [Safe by default](https://markdown-it-py.readthedocs.io/en/latest/security.html#md-security)
+- High speed (see our [benchmarking tests](https://markdown-it-py.readthedocs.io/en/latest/other.html#performance))
+- [Safe by default](https://markdown-it-py.readthedocs.io/en/latest/other.html#security)
 
 
 

--- a/docs/updates/2020-08-07-announce-book.md
+++ b/docs/updates/2020-08-07-announce-book.md
@@ -6,7 +6,7 @@
 :excerpt: 2
 ```
 
-*Note: this announcement is cross-posted between the [Jupyter Blog](https://blog.jupyter.org) and the [Executable Book Project updates blog](https://executablebooks.org/en/latest/updates/index.html)*
+*Note: this announcement is cross-posted between the [Jupyter Blog](https://blog.jupyter.org) and the [Executable Book Project updates blog](https://executablebooks.org/en/latest/updates.html)*
 
 Jupyter Book is an open source project for building beautiful, publication-quality books, websites, and documents from source material that contains computational content. With this post, we're happy to announce that Jupyter Book has been re-written from the ground up, making it easier to install, faster to use, and able to create more complex publishing content in your books. It is now supported by [the Executable Book Project](https://executablebooks.org/en/latest/), an open community that builds open source tools for interactive and executable documents in the Jupyter ecosystem and beyond.
 


### PR DESCRIPTION
This builds the documentation and runs a quick link check in an action on every push/pr. It uses the [lychee action](https://github.com/lycheeverse/lychee-action) and will fail tests if there's a broken link + print a text readout of the links that are not breaking that we can inspect to fix.

This will be particularly helpful for the gallery, to catch additions that break links, or links that have become outdated.