### PR TITLE
Update gallery.yml

### DIFF
--- a/docs/gallery.yml
+++ b/docs/gallery.yml
@@ -285,4 +285,4 @@
 - name: "Mathematik für Physikstudierende C"
   website: https://fau-ammn.github.io/MathPhysicsC/intro.html
   repository: https://github.com/FAU-AMMN/MathPhysicsC
-  image: https://github.com/FAU-AMMN/MathPhysicsC/blob/main/img/FAU_Nat_logo.svg
+  image: https://raw.githubusercontent.com/FAU-AMMN/MathPhysicsC/main/img/FAU_Nat_logo.svg

--- a/docs/gallery.yml
+++ b/docs/gallery.yml
@@ -282,3 +282,7 @@
   website: https://bdpedigo.github.io/networks-course
   repository: https://github.com/bdpedigo/networks-course
   image: https://raw.githubusercontent.com/bdpedigo/networks-course/main/docs/images/logo.png
+- name: "Mathematik für Physikstudierende C"
+  website: https://fau-ammn.github.io/MathPhysicsC/intro.html
+  repository: https://github.com/FAU-AMMN/MathPhysicsC
+  image: https://github.com/FAU-AMMN/MathPhysicsC/blob/main/img/FAU_Nat_logo.svg


### PR DESCRIPTION
Adds the lecture "Mathematik für Physikstudierende C" to the gallery, which is a lecture held at Friedrich--Alexander Universität Erlangen--Nürnberg.

While the lecture is in german and thus might not be accessible for most, it is an extensive showcase of the sphinx-proof package.