### PR TITLE
Add meeting notes and update template

### DIFF
--- a/.github/ISSUE_TEMPLATE/team-meeting.md
+++ b/.github/ISSUE_TEMPLATE/team-meeting.md
@@ -1,23 +1,23 @@
 ---
 name: Team Meeting 📅
 about: A team meeting
-title: 'EBP Team Meeting - {{ mmm YYYY }}'
+title: 'EBP Team Meeting - {{ MONTH }}'
 labels: meeting
 assignees: ''
 ---
 
 Hello @executablebooks/ebpteam! This is an issue to track the next Executable Books team meeting! Here's some relevant information:
 
-- **Date**: {{ YYYY-MM-DD }} at 7AM Sydney Time (or [your timezone](https://arewemeetingyet.com/Sydney/{{ YYYY-MM-DD }}/07:00/EBP-Team-Meeting)).
-- [**Agenda+Video links**](https://hackmd.io/THymMOAmSICp8rJdB6_Z1w?edit)
-- [**Google Calendar link**]({{ PUBLISH CALENDAR EVENT AND PASTE LINK HERE }} )
+- **Date**: {{ YYYY-MM-DD }}
+- **Time**: 7AM Sydney Time (**Wed** or **Thu** depending on your timezone).
+- [**Google Calendar Link**](https://calendar.google.com/calendar/embed?src=2nbh00hh9020u622nt0p5qhbek%40group.calendar.google.com&ctz=America%2FLos_Angeles).
+- [**Agenda+Video Links**](https://hackmd.io/THymMOAmSICp8rJdB6_Z1w?edit)
 
 If you'd like to discuss something at the meeting, please add an item to the agenda!
 
 ### Before the meeting
 
 - [ ] Update dates and make sure HackMD information is correct.
-- [ ] Create an event link from Google Calendar and paste above.
 - [ ] Team members add agenda items.
   
 ### After the meeting

--- a/docs/meetings/2022.md
+++ b/docs/meetings/2022.md
@@ -1,0 +1,43 @@
+# 2022
+
+## February
+
+### Attending
+
+- Matt McKay / ANU / @mmcky
+- Steve Purves / Curvenote / @stevejpurves
+- Chris H / 2i2c / @choldgraf
+- Franklin Koch / Curvenote / @fwkoch
+- Leif Walsh / Two Sigma / @leifwalsh
+- Rowan Cockett / Curvenote / @rowanc1 
+- Aakash Gupta / ANU / @aakashgc
+
+### Reports, updates, and celebrations
+
+- `sphinx-exercise==0.2.1` minor release with bug fixes and style updates
+- `sphinx-book-theme` refactor is ready for others to take a look: https://github.com/executablebooks/sphinx-book-theme
+- Aakash got the sphinx-theme-builder working for our theme: https://github.com/executablebooks/sphinx-book-theme/pull/469
+
+### Agenda items
+
+- [Matt] Planning to place an emphasis on Bug/Issue reduction for February (perhaps after the refactors for myst-parser, myst-nb) 
+  [Issue/Bug Reduction Priorities](https://github.com/executablebooks/meta/issues/649) is an issue on the meta repo to record any issues/bugs you are:
+  1. able to work on
+  2. really want fixed to move something forward
+- [Matt] Organise a session with Chris S on "The architecture of Jupyter Book" to flesh out some of the areas I am not familiar with such as: markdown-it / markdown-it-py etc. to make improvements for developer docs.
+    - Can you record this?! (@mmcky -- good idea)
+    - Three Common Ways to Extend Sphinx
+    - Overview of JupyterBook
+- [Steve] Thebe next steps - driven by requirements for hookup to interactive web components
+    - refactor to a (Typescript) core, update current js library to use it.
+    - library also made available on npm.
+    - Issue open for discussion here https://github.com/executablebooks/thebe/issues/536
+    - @mmcky If you need beta testers, we would be happy to help test on QuantEcon projects such as: https://python-programming.quantecon.org/intro.html
+- [Chris H] Feedback on book theme structure / visuals?
+  - Demo: https://sphinx-book-theme--472.org.readthedocs.build/en/472/
+  - General agreement that this looks a lot better than the current released version.
+- [Chris H] Feedback on carets / toggle buttons
+  - Demo: https://readthedocs.org/projects/sphinx-togglebutton/builds/15966583/
+  - Chevrons instead of + signs?
+  - Widescreen toggles - could we re-use from sphinx-design ?
+

--- a/docs/meetings/index.md
+++ b/docs/meetings/index.md
@@ -12,6 +12,7 @@ Below are notes from the Executable Books team meetings.
 
 ```{toctree}
 :maxdepth: 2
+2022.md
 2021.md
 ```
 


### PR DESCRIPTION
Updates our meeting template a bit, so the information is more consistent and there's just a single source of truth for meeting time / calendar link. Also adds meeting notes from last meeting.

Assuming that tests are happy, I'll merge so that I can create a new issue template.