### PR TITLE
STY, DOC: Fix spelling error in "developement"

### DIFF
--- a/docs/developer.md
+++ b/docs/developer.md
@@ -1,4 +1,4 @@
-# Developement Tips and Tricks
+# Development Tips and Tricks
 
 This section provides some useful tips and tricks for development of projects within the Executable Book Project ecosystem.
 


### PR DESCRIPTION
Spelling error: "Developement" should be "Development." I assume that fixing this in the heading will cascade through naturally to the table of contents in the navigation sidebar.