### PR TITLE
DOC: Add pyhf user guide and tutorial to gallery

### DIFF
--- a/docs/gallery.yml
+++ b/docs/gallery.yml
@@ -306,3 +306,7 @@
   website: https://climateestimate.net
   repository: https://github.com/atrisovic/weather-panel.github.io/
   image: https://climateestimate.net/_static/climate_estimate_logo.png
+- name: "pyhf User Guide and Tutorial"
+  website: https://pyhf.github.io/pyhf-tutorial/
+  repository: https://github.com/pyhf/pyhf-tutorial
+  image: https://github.com/scikit-hep/pyhf/raw/master/docs/_static/img/pyhf-logo.png


### PR DESCRIPTION
Add the [pyhf](https://github.com/scikit-hep/pyhf) [user guide and tutorial](https://pyhf.github.io/pyhf-tutorial/) to the Gallery of Jupyter Books.

c.f. https://github.com/scikit-hep/pyhf

(cc @lukasheinrich @kratsg)