### PR TITLE
Unpin sphinx

### DIFF
--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -24,4 +24,4 @@ jobs:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
         with:
           fail: true
-          args: docs/_build/**/*.html --exclude-link-local --exclude mailto --exclude discuss.executablebooks.org
+          args: docs/_build/**/*.html --exclude-link-local --exclude mailto --exclude discuss.executablebooks.org --exclude docs.github.com

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-sphinx
+sphinx>=4.0.0
 myst-parser[linkify]
 myst-nb
 sphinx-book-theme

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-sphinx~=3.5
+sphinx
 myst-parser[linkify]
 myst-nb
 sphinx-book-theme


### PR DESCRIPTION
This unpins the sphinx version in these docs. I'm not sure why it was pinned so let's see if this breaks anything. If nothing breaks, then this closes #720 