### PR TITLE
Fix: Use githubusercontent for images in gallery

### DIFF
--- a/docs/gallery.yml
+++ b/docs/gallery.yml
@@ -1,4 +1,4 @@
-- name: eChem: Computational Chemistry from Laptop to HPC
+- name: "eChem: Computational Chemistry from Laptop to HPC"
   website: https://kthpanor.github.io/echem/
   repository: https://github.com/kthpanor/echem
   image: https://raw.githubusercontent.com/kthpanor/echem/master/logo.png


### PR DESCRIPTION
Many images in the gallery are broken as they pull from github.com instead of githubusercontent.com. Fix this.