### PR TITLE
Fix documentation build

### DIFF
--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -24,5 +24,5 @@ jobs:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
         with:
           fail: true
-          args: docs/_build/**/*.html --insecure --exclude-link-local --exclude mailto --exclude discuss.executablebooks.org --exclude docs.github.com
+          args: docs/_build/**/*.html --insecure --exclude-link-local --exclude mailto
           jobSummary: true

--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -18,6 +18,8 @@ jobs:
           pip install -r requirements.txt
           sphinx-build docs docs/_build/html
 
+      # ref: https://github.com/lycheeverse/lychee-action
+      # ref: https://github.com/lycheeverse/lychee#commandline-parameters
       - name: Link Checker
         uses: lycheeverse/lychee-action@v1.5.0
         env:
@@ -29,7 +31,7 @@ jobs:
             docs/_build/**/*.html
             --insecure
             --max-retries 10
-            --exclude-mail
             --exclude-link-local
+            --exclude mailto
             --exclude https://github.com/executablebooks/meta/edit/master/docs/contributing.md
           jobSummary: true

--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -28,7 +28,8 @@ jobs:
           args: >
             docs/_build/**/*.html
             --insecure
+            --max-retries 10
+            --exclude-mail
             --exclude-link-local
-            --exclude mailto
             --exclude https://github.com/executablebooks/meta/edit/master/docs/contributing.md
           jobSummary: true

--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -19,9 +19,10 @@ jobs:
           sphinx-build docs docs/_build/html
 
       - name: Link Checker
-        uses: lycheeverse/lychee-action@v1.2.0
+        uses: lycheeverse/lychee-action@v1.5.0
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
         with:
           fail: true
           args: docs/_build/**/*.html --exclude-link-local --exclude mailto --exclude discuss.executablebooks.org --exclude docs.github.com
+          jobSummary: true

--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -24,5 +24,11 @@ jobs:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
         with:
           fail: true
-          args: docs/_build/**/*.html --insecure --exclude-link-local --exclude mailto
+          # github.com link below: This is a known fail
+          args: >
+            docs/_build/**/*.html
+            --insecure
+            --exclude-link-local
+            --exclude mailto
+            --exclude https://github.com/executablebooks/meta/edit/master/docs/contributing.md
           jobSummary: true

--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -24,5 +24,5 @@ jobs:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
         with:
           fail: true
-          args: docs/_build/**/*.html --exclude-link-local --exclude mailto --exclude discuss.executablebooks.org --exclude docs.github.com
+          args: docs/_build/**/*.html --insecure --exclude-link-local --exclude mailto --exclude discuss.executablebooks.org --exclude docs.github.com
           jobSummary: true

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -45,6 +45,7 @@ exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 
 # MyST Configuration
 myst_enable_extensions = ["colon_fence", "linkify"]
+myst_heading_anchors = 3
 
 # -- Options for HTML output -------------------------------------------------
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -36,7 +36,7 @@ blog_baseurl = "https://executablebooks.org"
 blog_feed_archives = True
 
 # Jupyter Notebooks configuration
-jupyter_execute_notebooks = "force"
+nb_execution_mode = "force"
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.

--- a/docs/gallery.yml
+++ b/docs/gallery.yml
@@ -46,10 +46,6 @@
   website: https://durgeshsamariya.github.io/learn-python/README.html
   repository: https://github.com/durgeshsamariya/learn-python
   image: https://raw.githubusercontent.com/durgeshsamariya/learn-python/main/resources/logo.png
-- name: The Arts Engagement Project
-  image: https://artsengagementproject.site/_static/logo.png
-  website: https://artsengagementproject.site/intro.html
-  repository: https://github.com/ArtsEngine/ArtsEngagementJupyterBook-Build
 - name: Algorithms for Automated Driving
   image: https://thomasfermi.github.io/Algorithms-for-Automated-Driving/_static/car_sketch_wide.png
   website: https://thomasfermi.github.io/Algorithms-for-Automated-Driving/Introduction/intro.html
@@ -97,7 +93,7 @@
 - name: Earth and Environmental Data Science
   website: http://earth-env-data-science.github.io/
   repository: https://github.com/earth-env-data-science/earth-env-data-science-book
-  image: https://raw.githubusercontent.com/earth-env-data-science/earth-env-data-science-book/master/content/images/logo/enso_sst.png
+  image: https://earth-env-data-science.github.io/_static/eeds-logo.png
 - name: DartBrains
   website: https://dartbrains.org/
   repository: https://github.com/ljchang/dartbrains
@@ -117,7 +113,7 @@
 - name: Deep Learning for Molecules and Materials
   website: https://whitead.github.io/dmol-book/
   repository: https://github.com/whitead/dmol-book
-  image: https://raw.githubusercontent.com/whitead/dmol-book/master/logo.png
+  image: https://dmol.pub/_static/robot-chem.png
 - name: genome-sampler Software Documentation
   website: https://caporasolab.us/genome-sampler/
   repository: https://github.com/caporaso-lab/genome-sampler

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -68,14 +68,14 @@ Sphinx ecosystem. It provides the following primary features:
 
 * **[Parse ipynb files in Sphinx](https://myst-nb.readthedocs.io/en/latest/#installation)**. Directly convert Jupyter
   Notebooks into Sphinx documents.
-* **[Execute and Cache your notebook content](https://myst-nb.readthedocs.io/en/latest/use/execute.html)**.
+* **[Execute and Cache your notebook content](https://myst-nb.readthedocs.io/en/latest/computation/execute.html)**.
   Save time building your documentation without needing to commit your notebook outputs
   directly into `git`.
-* **[Write MyST Markdown](https://myst-nb.readthedocs.io/en/latest/use/myst.html)**. MyST Markdown
+* **[Write MyST Markdown](https://myst-nb.readthedocs.io/en/latest/authoring/basics.html#myst-markdown)**. MyST Markdown
   allows you to write Sphinx roles and directives in markdown.
-* **[Insert notebook outputs into your content](https://myst-nb.readthedocs.io/en/latest/use/glue.html)**. Generate outputs
+* **[Insert notebook outputs into your content](https://myst-nb.readthedocs.io/en/latest/render/glue.html)**. Generate outputs
   as you build your documentation, and insert them across pages.
-* **[Write Jupyter Notebooks entirely with Markdown](https://myst-nb.readthedocs.io/en/latest/use/markdown.html)**. You can
+* **[Write Jupyter Notebooks entirely with Markdown](https://myst-nb.readthedocs.io/en/latest/authoring/text-notebooks.html)**. You can
   define the structure of a notebook *in pure-text* making it more diff-able.
 
 In addition, there are several options for controlling the look and feel of how your


### PR DESCRIPTION
Fixes our readthedocs builds, which I think have been broken once the MyST parser released a new version that changed the behavior on anchor links.

Also improves our link checker so that it adds a GitHub Actions summary in markdown when it fails.

Fixes a few links, but there are likely still some broken ones, will merge this one anyway so we un-break the docs.

closes https://github.com/executablebooks/meta/issues/765