### PR TITLE
Jupyter Books published by neurolibre.org

### DIFF
--- a/docs/gallery.yml
+++ b/docs/gallery.yml
@@ -334,3 +334,11 @@
   website: https://applying-maths-book.com/
   repository: https://github.com/subblue/applying-maths-book
   image: https://applying-maths-book.com/_static/book-cover.jpg
+- name: NiMARE: Neuroimaging Meta-Analysis Research Environment
+  website: https://neurolibre.org/papers/10.55458/neurolibre.00007
+  repository: https://github.com/NBCLab/nimare-paper
+  image: https://github.com/NBCLab/nimare-paper/blob/master/featured.png?raw=true
+- name: An interactive meta-analysis of MRI biomarkers of myelin
+  website: https://neurolibre.org/papers/10.55458/neurolibre.00004
+  repository: https://github.com/Notebook-Factory/myelin-meta-analysis
+  image: https://github.com/Notebook-Factory/myelin-meta-analysis/blob/main/featured.png?raw=true

--- a/docs/gallery.yml
+++ b/docs/gallery.yml
@@ -330,15 +330,15 @@
   website: https://particle1331.github.io/inefficient-networks/
   repository: https://github.com/particle1331/inefficient-networks
   image: https://particle1331.github.io/inefficient-networks/_static/pone.0237978.g001.png
-- name: Applying Maths in the Chemical and Biomolecular Sciences
+- name: "Applying Maths in the Chemical and Biomolecular Sciences"
   website: https://applying-maths-book.com/
   repository: https://github.com/subblue/applying-maths-book
   image: https://applying-maths-book.com/_static/book-cover.jpg
-- name: NiMARE: Neuroimaging Meta-Analysis Research Environment
+- name: "NiMARE: Neuroimaging Meta-Analysis Research Environment"
   website: https://neurolibre.org/papers/10.55458/neurolibre.00007
   repository: https://github.com/NBCLab/nimare-paper
   image: https://github.com/NBCLab/nimare-paper/blob/master/featured.png?raw=true
-- name: An interactive meta-analysis of MRI biomarkers of myelin
+- name: "An interactive meta-analysis of MRI biomarkers of myelin"
   website: https://neurolibre.org/papers/10.55458/neurolibre.00004
   repository: https://github.com/Notebook-Factory/myelin-meta-analysis
   image: https://github.com/Notebook-Factory/myelin-meta-analysis/blob/main/featured.png?raw=true


### PR DESCRIPTION
[Neuolibre](https://neurolibre.org) is approaching its beta release to publish jupyter books as reproducible neuroscience preprints! This pull request adds first two jupyter books published on NeuroLibre. 

As website, I provided DOI links that resolve into the respective publication pages.  `Reproducible preprint` button takes the reader to the Jupyter Book page. HTML and binderhub are served from our production servers.  

Alternatively, archived books can be downloaded by clicking the `JupyterBook archive` button. 

If this convention will be followed for the foreseeable future, I can have our editorial bot [roboneuro](https://roboneuro.herokuapp.com/) to send automated PRs each time a JupyterBook is published.

Thank you for maintaining this amazing project! 