### PR TITLE
Add CVE.icu to gallery of books

### DIFF
--- a/docs/gallery.yml
+++ b/docs/gallery.yml
@@ -1,3 +1,7 @@
+- name: CVE.icu
+  website: https://cve.icu
+  repository: https://github.com/jgamblin/cve.icu
+  image: https://raw.githubusercontent.com/jgamblin/cve.icu/main/ambulance.png
 - name: Open Source in Environmental Sustainability
   website: https://report.opensustain.tech/
   repository: https://github.com/protontypes/open-source-in-environmental-sustainability


### PR DESCRIPTION
[CVE.icu](https://cve.icu) is a jupyterbook project I run to display CVE data from NVD and MITRE that is updated daily using github actions.   It would be amazing if it can be added to the gallery as an example. 

