### PR TITLE
Update myst-tools link

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -117,7 +117,7 @@ Our team policies, structure, practices, and contributing guides.
 :::
 
 :::{grid-item-card}
-:link: https://www.myst.tools/
+:link: https://myst-tools.org
 :class-header: myst-logo-sq
 
 MyST tools overview ![](https://myst-parser.readthedocs.io/en/latest/_images/logo-square.svg)


### PR DESCRIPTION
Updates a myst.tools link to avoid redirects for folks who may not be able to access the myst.tools domain.