### PR TITLE
docs: use pagination for GhApi

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -89,7 +89,7 @@ import requests
 from subprocess import run
 from textwrap import dedent
 from urllib.parse import urlparse
-from ghapi.all import GhApi
+from ghapi.all import GhApi, paged
 import pandas as pd
 
 import yaml
@@ -200,8 +200,10 @@ def update_feature_votes(app: Sphinx):
     LOGGER.info("Retrieving feature voting issue data...")
     for repo in repos:
         for kind in ["enhancement", "type/enhancement", "type/documentation"]:
-            issues += api.issues.list_for_repo(
-                "executablebooks", repo["name"], labels=kind, per_page=100, state="open"
+            issues.extend(
+                paged(api.issues.list_for_repo,
+                    owner="executablebooks", repo=repo["name"], labels=kind, state="open"
+                )
             )
 
     # Extract the metadata that we want

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -82,6 +82,7 @@ rediraffe_redirects = {
 }
 
 # -- Custom scripts ----------------------------------------------------------
+import itertools
 import os
 from pathlib import Path
 import random
@@ -201,8 +202,10 @@ def update_feature_votes(app: Sphinx):
     for repo in repos:
         for kind in ["enhancement", "type/enhancement", "type/documentation"]:
             issues.extend(
-                paged(api.issues.list_for_repo,
-                    owner="executablebooks", repo=repo["name"], labels=kind, state="open"
+                itertools.chain.from_iterable(
+                    paged(api.issues.list_for_repo,
+                        owner="executablebooks", repo=repo["name"], labels=kind, state="open"
+                    )
                 )
             )
 


### PR DESCRIPTION
GhApi's `per_page` [is limited to 100](https://ghapi.fast.ai/page.html#paged-operations), so we must use pagination to read more than 100 entries. This is currently manifesting as missing entries in [the feature-voting table](https://executablebooks.org/en/latest/feature-vote/).