### PR TITLE
fix: drop https://docs.datapartnership.org

### DIFF
--- a/docs/gallery.yml
+++ b/docs/gallery.yml
@@ -190,10 +190,6 @@
   repository: https://github.com/rafneta/CienciaDatosPythonCIDE
   image: https://raw.githubusercontent.com/rafneta/CienciaDatosPythonCIDE/master/docs/logo.jpg
   website: https://rafneta.github.io/CienciaDatosPythonCIDE/intro.html
-- name: "Development Data Partnership"
-  repository:
-  image: https://raw.githubusercontent.com/datapartnership/welcome/master/images/logo.png
-  website: https://docs.datapartnership.org
 - name: "OpenPifPaf Guide"
   image: https://openpifpaf.github.io/_static/logo.png
   website: https://openpifpaf.github.io


### PR DESCRIPTION
This resource is now private