### PR TITLE
Use trailing slash in URL for social cards

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -75,7 +75,7 @@ intersphinx_mapping = {"jb": ("https://jupyterbook.org/en/latest", None), "tc": 
 ogp_social_cards = {
     "image": "_static/logo-square.png",
 }
-ogp_site_url = "https://executablebooks.org/en/latest"
+ogp_site_url = "https://executablebooks.org/en/latest/"
 
 # Redirections
 rediraffe_redirects = {


### PR DESCRIPTION
This should fix our broken social previews :crossed_fingers: 