### PR TITLE
fix URL redirect

### DIFF
--- a/docs/gallery.yml
+++ b/docs/gallery.yml
@@ -158,7 +158,7 @@
   repository: https://github.com/alan-turing-institute/the-turing-way
   image: https://raw.githubusercontent.com/alan-turing-institute/the-turing-way/master/book/website/figures/logo/logo.png
 - name: Deep Learning for Molecules and Materials
-  website: https://whitead.github.io/dmol-book/
+  website: https://dmol.pub
   repository: https://github.com/whitead/dmol-book
   image: https://raw.githubusercontent.com/whitead/dmol-book/master/_static/images/logo.png
 - name: genome-sampler Software Documentation


### PR DESCRIPTION
https://whitead.github.io/dmol-book/ -> https://dmol.pub